### PR TITLE
Add quotation marks for attributes alias

### DIFF
--- a/doc/marshalling.rst
+++ b/doc/marshalling.rst
@@ -387,7 +387,7 @@ All you have to do is subclass :class:`~fields.Raw` and implement the :meth:`~fi
     # example usage
     fields = {
         'name': fields.String,
-        'all_caps_name': AllCapsString(attribute=name),
+        'all_caps_name': AllCapsString(attribute='name'),
     }
 
 You can also use the :attr:`__schema_format__`, ``__schema_type__`` and


### PR DESCRIPTION
In "Custom fields" example, this 'all_caps_name' is an alias for attribute 'name', while I believe there should be quotation marks for the attribute.